### PR TITLE
Updates the Middleware to now pass requestDetails.

### DIFF
--- a/packages/core/src/middleware/messageValidation.ts
+++ b/packages/core/src/middleware/messageValidation.ts
@@ -16,9 +16,9 @@ const PROTO_OPTIONS = {
 export function createMessageValidator(pbjsService: pbjs.Service): Middleware<any, any> {
   pbjsService.resolveAll();
 
-  return (req$, ctx, deps, next, methodName) => {
-    const reqMessage = pbjsService.methods[methodName as string].resolvedRequestType;
-    const resMessage = pbjsService.methods[methodName as string].resolvedResponseType;
+  return (req$, ctx, deps, next, { method }) => {
+    const reqMessage = method.resolvedRequestType;
+    const resMessage = method.resolvedResponseType;
 
     const validated$ = req$.pipe(
       map(d => {

--- a/packages/core/src/middleware/messageValidation.ts
+++ b/packages/core/src/middleware/messageValidation.ts
@@ -13,8 +13,7 @@ const PROTO_OPTIONS = {
   oneofs: true, // includes virtual oneof fields set to the present field's name
 };
 
-export function createMessageValidator(pbjsService: pbjs.Service): Middleware<any, any> {
-  pbjsService.resolveAll();
+export function createMessageValidator(): Middleware<any, any> {
 
   return (req$, ctx, deps, next, { method }) => {
     const reqMessage = method.resolvedRequestType;

--- a/packages/core/src/service.test.ts
+++ b/packages/core/src/service.test.ts
@@ -161,8 +161,8 @@ describe('Service', () => {
         s.registerServiceHandler('increment', handler);
       });
 
-      it('invokes middleware with the name of the method called', () => {
-        const middleware = jest.fn((req, ctx, deps, next, methodName) => {
+      it('invokes middleware with requestDetails that include the of the method called', () => {
+        const middleware = jest.fn((req, ctx, deps, next, requestDetails) => {
           return next(req, ctx);
         });
         s.addMiddleware(middleware);
@@ -172,12 +172,12 @@ describe('Service', () => {
         return response.toPromise().then(() => {
           expect(middleware).toHaveBeenCalledTimes(1);
           const args = middleware.mock.calls[0];
-          expect(args[4]).toEqual('increment');
+          expect(args[4].method.name).toEqual('increment');
         });
       });
 
       it('invokes middleware with the registered dependencies', () => {
-        const middleware = jest.fn((req, ctx, deps, next, methodName) => {
+        const middleware = jest.fn((req, ctx, deps, next, requestDetails) => {
           return next(req, ctx);
         });
         s.addMiddleware(middleware);
@@ -205,7 +205,7 @@ describe('Service', () => {
         })
 
         const decoratingProxy = jest.fn((call) => call())
-        const middleware = jest.fn((req, ctx, deps, next, methodName) => {
+        const middleware = jest.fn((req, ctx, deps, next, requestDetails) => {
 
           const userService = {
             ...deps.usersSvc,
@@ -397,7 +397,7 @@ describe('Service', () => {
 
   describe('cancelation', () => {
     it('skips the stack if context is already canceled', async () => {
-      const middleware = jest.fn((req, ctx, deps, next, methodName) => {
+      const middleware = jest.fn((req, ctx, deps, next, requestDetails) => {
         return next(req, ctx);
       });
       s.addMiddleware(middleware);

--- a/packages/core/src/service.test.ts
+++ b/packages/core/src/service.test.ts
@@ -161,7 +161,7 @@ describe('Service', () => {
         s.registerServiceHandler('increment', handler);
       });
 
-      it('invokes middleware with requestDetails that include the of the method called', () => {
+      it('should invoke middleware with requestDetails that includes the method object with correct name called', () => {
         const middleware = jest.fn((req, ctx, deps, next, requestDetails) => {
           return next(req, ctx);
         });

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -15,7 +15,6 @@ export interface Handler<TReq, TRes, TDependencies extends object = {}> {
   >;
 }
 
-
 type RequestDetails =  {
   method: Method
 };
@@ -63,7 +62,8 @@ export class Service<
   constructor(protoService: pbjs.Service, dependencies: TDependencies) {
     this.pbjsService = protoService;
     this._dependencies = dependencies;
-    this.addMiddleware(createMessageValidator(this.pbjsService));
+    this.pbjsService.resolveAll();
+    this.addMiddleware(createMessageValidator());
   }
 
   private _notImplemented = (methodName: keyof TService) => () => {


### PR DESCRIPTION
Updates the Middleware to now pass requestDetails that now includes the called method.
This allows middleware implementors to determine the type of req$ they are working with. ie. Whether it's a Bidirectional or Unary req.

By adding requestDetails this will allow us to avoid breaking the api as little as possible when needing to pass request specific details to middleware.