### PR TITLE
Adds a new GrpcClient pool

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@types-first-api/core",
-	"version": "0.0.8",
+	"version": "0.0.13",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/grpc-client/src/grpcClient.ts
+++ b/packages/grpc-client/src/grpcClient.ts
@@ -17,8 +17,8 @@ import { EMPTY, Subject } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 export class GrpcClient<TService extends GRPCService<TService>> extends Client<TService> {
-  private _client: grpc.Client;
-  private methods: Record<keyof TService, grpc.MethodDefinition<any, any>>;
+  private readonly _client: grpc.Client;
+  private readonly methods: Record<keyof TService, grpc.MethodDefinition<any, any>>;
 
   constructor(protoService: pbjs.Service, address: ClientAddress) {
     super(protoService, address);
@@ -36,6 +36,10 @@ export class GrpcClient<TService extends GRPCService<TService>> extends Client<T
     ) as Record<keyof TService, grpc.MethodDefinition<any, any>>;
     const addressString = `${address.host}:${address.port}`;
     this._client = new GrpcClient(addressString, grpc.credentials.createInsecure());
+  }
+
+  public getClient(): grpc.Client {
+    return this._client;
   }
 
   _call<K extends keyof TService>(

--- a/packages/grpc-client/src/index.ts
+++ b/packages/grpc-client/src/index.ts
@@ -1,1 +1,2 @@
 export * from './grpcClient';
+export * from './pooledGrpcClient';

--- a/packages/grpc-client/src/pooledGrpcClient.ts
+++ b/packages/grpc-client/src/pooledGrpcClient.ts
@@ -1,0 +1,85 @@
+import {Client, ClientAddress, Context, GRPCService,} from '@types-first-api/core';
+import * as grpc from 'grpc';
+import * as _ from 'lodash';
+import * as pbjs from 'protobufjs';
+import {Observable} from 'rxjs';
+import {GrpcClient} from "./grpcClient";
+
+
+interface PoolEntry<TService extends GRPCService<TService>> {
+  initTime: number,
+  client: GrpcClient<TService>
+}
+
+
+/*
+  Creates a pool of GrpcClients that allow for connection expiration and rotation between a set of clients.
+
+  By default, the GrpcClient will create a single channel (HTTP/2 connection), which means that any HTTP/1.1 or TCP
+  load balancers will not be able to distribute requests from this client to multiple backing service instances.
+ 
+ */
+export class PooledGrpcClient<TService extends GRPCService<TService>> extends Client<TService> {
+
+  // The maximum time for a GrpcClient to be used by the application
+  private readonly MAX_CLIENT_LIFE_MS = 1000;
+  // Wait for up to 90 seconds for a connection to change states to idle before shutting down
+  private readonly MAX_SHUTDOWN_WAIT = 1000 * 90;
+
+  private readonly CONNECTION_POOL_SIZE = 12;
+
+  private readonly _clientPool: PoolEntry<TService>[] = [];
+
+  private _nextPoolIndex = 0;
+
+  constructor(private protoService: pbjs.Service, private address: ClientAddress) {
+    super(protoService, address);
+    this._clientPool = _.range(this.CONNECTION_POOL_SIZE).map(i => {
+      return {
+        client: new GrpcClient<TService>(protoService, address),
+        initTime: Date.now()
+      }
+    });
+  }
+
+  _call<K extends keyof TService>(methodName: K, req$: Observable<TService[K]["request"]>, ctx: Context): Observable<TService[K]["response"]> {
+    return this.getNextClient()._call(methodName, req$, ctx);
+  }
+
+  private getNextClient = (): GrpcClient<TService> => {
+    const index = this._nextPoolIndex;
+    const nextEntry: PoolEntry<TService> = this._clientPool[index];
+
+    this._nextPoolIndex = (++this._nextPoolIndex) % this.CONNECTION_POOL_SIZE;
+
+    if (nextEntry.initTime + this.MAX_CLIENT_LIFE_MS >= Date.now()) {
+      const replacement = {
+        client: new GrpcClient<TService>(this.protoService, this.address),
+        initTime: Date.now()
+      };
+      this._clientPool[index] = replacement;
+      this.shutdownOnIdle(nextEntry);
+
+      return replacement.client;
+    }
+
+    return nextEntry.client;
+  };
+
+  private shutdownOnIdle = (entry: PoolEntry<TService>) => {
+    const channel = entry.client.getClient().getChannel();
+    channel.watchConnectivityState(channel.getConnectivityState(false), this.MAX_SHUTDOWN_WAIT, (err) => {
+      if (err) {
+        console.log("Channel failed to transition to a different state in allotted time frame");
+      }
+      // Only shutdown a client if it is IDLE.
+      if (channel.getConnectivityState(false) === grpc.connectivityState.IDLE) {
+        entry.client.getClient().close();
+        return;
+      }
+      // If we didn't get the transition we want, try again
+      this.shutdownOnIdle(entry);
+    });
+  };
+
+}

--- a/packages/grpc-common/package-lock.json
+++ b/packages/grpc-common/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@types-first-api/grpc-common",
-	"version": "0.0.8",
+	"version": "0.0.13",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/grpc-server/package-lock.json
+++ b/packages/grpc-server/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@types-first-api/grpc-server",
-	"version": "0.0.8",
+	"version": "0.0.13",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-client/package-lock.json
+++ b/packages/http-client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@types-first-api/http-client",
-	"version": "0.0.8",
+	"version": "0.0.13",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-common/package-lock.json
+++ b/packages/http-common/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@types-first-api/http-common",
-	"version": "0.0.8",
+	"version": "0.0.13",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-server/package-lock.json
+++ b/packages/http-server/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@types-first-api/http-server",
-	"version": "0.0.8",
+	"version": "0.0.13",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Works around single-socket punch through for legacy load balancers by creating a pool of clients and expiring those clients over time 