### PR TITLE
Adds grpc client options to client factory and Client interface

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -27,7 +27,8 @@ export interface ClientMiddleware<TService extends GRPCService<TService>> {
 
 export type ClientConstructor<TService extends GRPCService<TService>> = new (
   protoService: pbjs.Service,
-  address: ClientAddress
+  address: ClientAddress,
+  options?: Record<string, any>
 ) => Client<TService>;
 
 export interface ClientAddress {
@@ -39,10 +40,12 @@ export abstract class Client<TService extends GRPCService<TService>> {
   private _middleware: ClientMiddleware<TService>[] = [];
 
   protected pbjsService: pbjs.Service;
+  protected options:  Record<string, any> = {};
   rpc: RpcCallMap<TService>;
 
-  constructor(protoService: pbjs.Service, address: ClientAddress) {
+  constructor(protoService: pbjs.Service, address: ClientAddress, options: Record<string, any> = {}) {
     this.pbjsService = protoService;
+    this.options = options;
     this.rpc = _.mapValues<Record<string, pbjs.Method>, RpcCall<any, any>>(
       protoService.methods,
       (m, methodName) => {

--- a/packages/core/src/clientFactory.ts
+++ b/packages/core/src/clientFactory.ts
@@ -10,14 +10,15 @@ export function clientFactory<TServices extends GRPCServiceMap<TServices>>(
   function create<K extends Extract<keyof TServices, string>>(
     serviceName: K,
     address: ClientAddress,
-    ClientImpl: ClientConstructor<TServices[K]>
+    ClientImpl: ClientConstructor<TServices[K]>,
+    options?: Record<string, any>
   ) {
     const pbjsService = root.lookupService(serviceName);
     if (pbjsService == null) {
       throw new Error(`Unable to create instance of unknown service: ${serviceName}`);
     }
 
-    return new ClientImpl(pbjsService, address);
+    return new ClientImpl(pbjsService, address, options);
   }
 
   return { create };

--- a/packages/grpc-client/src/grpcClient.ts
+++ b/packages/grpc-client/src/grpcClient.ts
@@ -20,11 +20,12 @@ export class GrpcClient<TService extends GRPCService<TService>> extends Client<T
   private readonly _client: grpc.Client;
   private readonly methods: Record<keyof TService, grpc.MethodDefinition<any, any>>;
 
-  constructor(protoService: pbjs.Service, address: ClientAddress) {
-    super(protoService, address);
+  constructor(protoService: pbjs.Service, address: ClientAddress, options: Record<string, any> = {}) {
+    super(protoService, address, options);
     const GrpcClient = grpc.loadObject(protoService, {
       enumsAsStrings: false,
     }) as typeof grpc.Client;
+
     const serviceDef = (GrpcClient as any).service as grpc.ServiceDefinition<any>;
     this.methods = _.reduce(
       serviceDef,
@@ -35,7 +36,7 @@ export class GrpcClient<TService extends GRPCService<TService>> extends Client<T
       {}
     ) as Record<keyof TService, grpc.MethodDefinition<any, any>>;
     const addressString = `${address.host}:${address.port}`;
-    this._client = new GrpcClient(addressString, grpc.credentials.createInsecure());
+    this._client = new GrpcClient(addressString, grpc.credentials.createInsecure(), options);
   }
 
   public getClient(): grpc.Client {

--- a/packages/grpc-client/src/pooledGrpcClient.ts
+++ b/packages/grpc-client/src/pooledGrpcClient.ts
@@ -5,12 +5,10 @@ import * as pbjs from 'protobufjs';
 import {Observable} from 'rxjs';
 import {GrpcClient} from "./grpcClient";
 
-
 interface PoolEntry<TService extends GRPCService<TService>> {
   initTime: number,
   client: GrpcClient<TService>
 }
-
 
 /*
   Creates a pool of GrpcClients that allow for connection expiration and rotation between a set of clients.
@@ -32,8 +30,8 @@ export class PooledGrpcClient<TService extends GRPCService<TService>> extends Cl
 
   private _nextPoolIndex = 0;
 
-  constructor(private protoService: pbjs.Service, private address: ClientAddress) {
-    super(protoService, address);
+  constructor(private protoService: pbjs.Service, private address: ClientAddress, options: Record<string, any> = {}) {
+    super(protoService, address, options);
     this._clientPool = _.range(this.CONNECTION_POOL_SIZE).map(() => this.createPoolEntry());
   }
 
@@ -60,7 +58,7 @@ export class PooledGrpcClient<TService extends GRPCService<TService>> extends Cl
 
   private createPoolEntry = () => {
     return {
-      client: new GrpcClient<TService>(this.protoService, this.address),
+      client: new GrpcClient<TService>(this.protoService, this.address, this.options),
       initTime: Date.now()
     };
   };


### PR DESCRIPTION
Adds grpc client options to client factory and Client interface. 
This should enable users of types-first-api to pass options that the underlying clients need.